### PR TITLE
Avoiding DockerHub pull limits

### DIFF
--- a/vscodespaces/TOC.yml
+++ b/vscodespaces/TOC.yml
@@ -28,6 +28,8 @@
 - name: Reference
   items: 
 
+  - name: Avoiding DockerHub Pull Limits
+    href: reference/dockerhub.md
   - name: Configuring environments
     href: reference/configuring.md
   - name: Configuring Windows environments

--- a/vscodespaces/overview/what-is-vsonline.md
+++ b/vscodespaces/overview/what-is-vsonline.md
@@ -59,6 +59,8 @@ This array of editor options allows developers to use their preferred tooling fr
 
 Visual Studio Codespaces is built to accommodate the widest variety of projects or tasks. Developers can start with smart-configuration features that provide common defaults, or finely-tune environments with custom JSON and Dockerfile configuration.
 
+> [!WARNING] To avoid [DockerHub pull limits](https://www.docker.com/pricing/resource-consumption-updates), we strongly recommend using images from the Microsoft container registry such as the [.NET images](https://hub.docker.com/_/microsoft-dotnet) or the [pre-built dev container images](https://hub.docker.com/_/microsoft-vscode-devcontainers). You may also push DockerHub images you are using to another public registry like [GitHub Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry) or transition to [GitHub Codespaces](https://github.com/features/codespaces) which should not experience these issues.
+
 Flexible configuration allows developers to rapidly onboard on projects with unique configuration and requirements that are difficult to apply on a local machine. Additionally, reproducible development environments eliminate "works on my machine" problems.
 
 ### Personal configuration

--- a/vscodespaces/reference/configuring.md
+++ b/vscodespaces/reference/configuring.md
@@ -91,6 +91,8 @@ Containers should be able to fulfill requirements of both [VS Code Remote Server
 
 Start provisioning a container by including a **devcontainer.json** file in the project repository. A terminal containing the details of the build process will appear, and can be used to aid in diagnosing creation failures.
 
+> [!WARNING] To avoid [DockerHub pull limits](https://www.docker.com/pricing/resource-consumption-updates), we strongly recommend using images from the Microsoft container registry such as the [.NET images](https://hub.docker.com/_/microsoft-dotnet) or the [pre-built dev container images](https://hub.docker.com/_/microsoft-vscode-devcontainers). You may also push DockerHub images you are using to another public registry like [GitHub Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry) or transition to [GitHub Codespaces](https://github.com/features/codespaces) which should not experience these issues.
+
 ### Image support
 
 Add the `image` argument and value to a **devcontainer.json** file in the project repository. The image must be in a public repository.

--- a/vscodespaces/reference/dockerhub.md
+++ b/vscodespaces/reference/dockerhub.md
@@ -15,7 +15,7 @@ Docker [recently announced](https://www.docker.com/pricing/resource-consumption-
 
 Since Visual Studio Codespaces resides in Azure, **IPs are not predictable**, so this could affect you in two ways:
 
-1. If you use a custom image, Dockerfile, or Docker Compose file that referneces a DockerHub image, you may experience throttling when creating a codespace.
+1. If you use a custom image, Dockerfile, or Docker Compose file that references a DockerHub image, you may experience throttling when creating a codespace.
 2. Once inside a codespace, you may experience throttling when using the Docker CLI inside the codespace.
 
 > [!NOTE] The default Codespaces image is not affected by these pull limits.

--- a/vscodespaces/reference/dockerhub.md
+++ b/vscodespaces/reference/dockerhub.md
@@ -11,9 +11,9 @@ ms.date: 10/28/2020
 
 # Avoiding DockerHub Pull Limits
 
-Docker [recently announced](https://www.docker.com/pricing/resource-consumption-updates) that there will be limits on the number of image "pulls" their free tiers provide starting November 2nd, 2020. This includes pulling images from DockerHub as when building an image. Critically, there is a limit of 100 anonymous pulls per-IP every six hours.
+Docker [recently announced](https://www.docker.com/pricing/resource-consumption-updates) that there will be limits on the number of image "pulls" their free tiers provide starting November 2nd, 2020. This includes pulling images from DockerHub when building an a custom image. Critically, there is a limit of **100 anonymous pulls per-IP** every six hours.
 
-Since Visual Studio Codespaces resides in Azure, IPs are not predictable, so this could affect you in two ways:
+Since Visual Studio Codespaces resides in Azure, **IPs are not predictable**, so this could affect you in two ways:
 
 1. If you use a custom image, Dockerfile, or Docker Compose file that referneces a DockerHub image, you may experience throttling when creating a codespace.
 2. Once inside a codespace, you may experience throttling when using the Docker CLI inside the codespace.

--- a/vscodespaces/reference/dockerhub.md
+++ b/vscodespaces/reference/dockerhub.md
@@ -31,7 +31,7 @@ If you need to continue to create new codspaces in VS Codespaces until November 
 
 ## Avoiding throttling when working with Docker inside a codespace
 
-Once inside a codespace, you can avoid these limits by simply [loggig into the Docker CLI](https://docs.docker.com/engine/reference/commandline/login/). Logging in with free account will give your user 200 pulls every six hours and is not subject to IP limits. There are also [paid tiers](https://www.docker.com/pricing) that lift this limit entirely.
+Once inside a codespace, you can avoid these limits by simply [logging into the Docker CLI](https://docs.docker.com/engine/reference/commandline/login/). Logging in with free account will give your user 200 pulls every six hours and is not subject to IP limits. There are also [paid tiers](https://www.docker.com/pricing) that lift this limit entirely.
 
 To log in, start a terminal in your codespace and run:
 

--- a/vscodespaces/reference/dockerhub.md
+++ b/vscodespaces/reference/dockerhub.md
@@ -31,9 +31,9 @@ If you need to continue to create new codspaces in VS Codespaces until November 
 
 ## Avoiding throttling when working with Docker inside a codespace
 
-Once inside a codespace, you can avoid these limits by simply [loggig into the Docker CLI](https://docs.docker.com/engine/reference/commandline/login/). A free account and you can raise the pull request limits to 200 every six hours for your user and is not subject to IP limits. There are also [paid tiers](https://www.docker.com/pricing) that lift this limit entirely.
+Once inside a codespace, you can avoid these limits by simply [loggig into the Docker CLI](https://docs.docker.com/engine/reference/commandline/login/). Logging in with free account will give your user 200 pulls every six hours and is not subject to IP limits. There are also [paid tiers](https://www.docker.com/pricing) that lift this limit entirely.
 
-From a terminal, run:
+To log in, start a terminal in your codespace and run:
 
 ```bash
 docker login -u your-user-name-here

--- a/vscodespaces/reference/dockerhub.md
+++ b/vscodespaces/reference/dockerhub.md
@@ -1,0 +1,40 @@
+---
+author: chuxel
+ms.author: clantz
+ms.prod: visual-studio-family
+ms.technology: visual-studio-codespaces
+title: DockerHub
+description: Avoiding DockerHub Pull Limits
+ms.topic: reference
+ms.date: 10/28/2020
+---
+
+# Avoiding DockerHub Pull Limits
+
+Docker [recently announced](https://www.docker.com/pricing/resource-consumption-updates) that there will be limits on the number of image "pulls" their free tiers provide starting November 2nd, 2020. This includes pulling images from DockerHub as when building an image. Critically, there is a limit of 100 anonymous pulls per-IP every six hours.
+
+Since Visual Studio Codespaces resides in Azure, IPs are not predictable, so this could affect you in two ways:
+
+1. If you use a custom image, Dockerfile, or Docker Compose file that referneces a DockerHub image, you may experience throttling when creating a codespace.
+2. Once inside a codespace, you may experience throttling when using the Docker CLI inside the codespace.
+
+> [!NOTE] The default Codespaces image is not affected by these pull limits.
+
+## Avoiding throttling when creating a codespace
+
+It is worth noting that [GitHub Codespaces](https://github.com/features/codespaces) should not experience this throttling and will also have the ability to allow you to sign in to DockerHub over time. We recommend transitioning to GitHub Codespaces to side step this problem entirely. Codespace creation will be disabled in VS Codespaces on November 20th, 2020 as a part of the transition so this is another good reason to transition.
+
+If you need to continue to create new codspaces in VS Codespaces until November 20th, we strongly recommend not using public images from DockerHub and instead either:
+
+- Using images from the Microsoft container registry like the [.NET images](https://hub.docker.com/_/microsoft-dotnet) or the [pre-built dev container images](https://hub.docker.com/_/microsoft-vscode-devcontainers).
+- Pushing your DockerHub images to another public registry like [GitHub Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry) and referencing these instead.
+
+## Avoiding throttling when working with Docker inside a codespace
+
+Once inside a codespace, you can avoid these limits by simply [loggig into the Docker CLI](https://docs.docker.com/engine/reference/commandline/login/). A free account and you can raise the pull request limits to 200 every six hours for your user and is not subject to IP limits. There are also [paid tiers](https://www.docker.com/pricing) that lift this limit entirely.
+
+From a terminal, run:
+
+```bash
+docker login -u your-user-name-here
+```


### PR DESCRIPTION
This article adds in information on avoiding DockerHub pull limits that take effect on Nov 2nd, 2020.